### PR TITLE
add hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,8 @@
 		maxBounds: [
 			[-74.33, 40.41], // Southwest coordinates
 			[-73.63, 40.98] // Northeast coordinates
-		]
+		],
+		hash: true
   });
 
 	map.addControl(new mapboxgl.NavigationControl());


### PR DESCRIPTION
Great work on this map, it's a much needed visual of our inadequate distancing space.

This PR adds the `hash: true` option to the mapboxGL map, allowing for deep linking to a specific spot on the map.

I'd also suggest you host the site with https to avoid it being blocked by people's firewalls.  This is easy to set up with netlify.com.  I'm happy to help if you are interested.